### PR TITLE
Organize imports so that cargo fmt can lint them better

### DIFF
--- a/attestation-transformer/src/did.rs
+++ b/attestation-transformer/src/did.rs
@@ -84,7 +84,7 @@ impl From<Did> for String {
 mod test {
 	use crate::did::Schema;
 
-	use super::Did;
+	use super::*;
 
 	#[test]
 	fn test_did_parsing() {

--- a/attestation-transformer/src/main.rs
+++ b/attestation-transformer/src/main.rs
@@ -6,19 +6,20 @@ use serde_json::from_str;
 use tonic::transport::Channel;
 use tonic::{transport::Server, Request, Response, Status};
 
-use error::AttTrError;
-use managers::checkpoint::CheckpointManager;
-use managers::term::TermManager;
 use proto_buf::combiner::linear_combiner_client::LinearCombinerClient;
 use proto_buf::indexer::indexer_client::IndexerClient;
 use proto_buf::indexer::{IndexerEvent, Query};
 use proto_buf::transformer::transformer_server::{Transformer, TransformerServer};
 use proto_buf::transformer::{EventBatch, EventResult, TermBatch, TermResult};
-use schemas::security::SecurityReportSchema;
-use schemas::status::StatusSchema;
-use schemas::trust::TrustSchema;
-use schemas::{IntoTerm, SchemaType};
-use term::Term;
+
+use crate::error::AttTrError;
+use crate::managers::checkpoint::CheckpointManager;
+use crate::managers::term::TermManager;
+use crate::schemas::security::SecurityReportSchema;
+use crate::schemas::status::StatusSchema;
+use crate::schemas::trust::TrustSchema;
+use crate::schemas::{IntoTerm, SchemaType};
+use crate::term::Term;
 
 pub mod did;
 pub mod error;
@@ -197,7 +198,8 @@ mod test {
 	use crate::schemas::{Domain, Proof};
 	use crate::term::Term;
 	use crate::utils::address_from_ecdsa_key;
-	use crate::TransformerService;
+
+	use super::*;
 
 	impl StatusSchema {
 		pub fn generate(id: String, current_status: CurrentStatus) -> Self {

--- a/attestation-transformer/src/managers/checkpoint.rs
+++ b/attestation-transformer/src/managers/checkpoint.rs
@@ -1,5 +1,6 @@
-use crate::error::AttTrError;
 use rocksdb::DB;
+
+use crate::error::AttTrError;
 
 #[derive(Debug)]
 pub struct CheckpointManager;
@@ -50,7 +51,7 @@ impl CheckpointManager {
 mod test {
 	use rocksdb::{Options, DB};
 
-	use crate::managers::checkpoint::CheckpointManager;
+	use super::*;
 
 	#[test]
 	fn should_write_read_checkpoint() {

--- a/attestation-transformer/src/managers/term.rs
+++ b/attestation-transformer/src/managers/term.rs
@@ -1,8 +1,10 @@
 use itertools::Itertools;
-use proto_buf::transformer::{TermBatch, TermObject};
 use rocksdb::{WriteBatch, DB};
 
-use crate::{error::AttTrError, term::Term};
+use proto_buf::transformer::{TermBatch, TermObject};
+
+use crate::error::AttTrError;
+use crate::term::Term;
 
 #[derive(Debug)]
 pub struct TermManager;
@@ -60,10 +62,14 @@ impl TermManager {
 #[cfg(test)]
 mod test {
 	use itertools::Itertools;
-	use proto_buf::transformer::{TermBatch, TermObject};
 	use rocksdb::{Options, DB};
 
-	use crate::{managers::term::TermManager, schemas::Domain, term::Term};
+	use proto_buf::transformer::{TermBatch, TermObject};
+
+	use crate::schemas::Domain;
+	use crate::term::Term;
+
+	use super::*;
 
 	#[test]
 	fn should_write_read_term() {

--- a/attestation-transformer/src/schemas/mod.rs
+++ b/attestation-transformer/src/schemas/mod.rs
@@ -1,10 +1,9 @@
-use crate::{error::AttTrError, term::Term};
-use secp256k1::{
-	ecdsa::{RecoverableSignature, RecoveryId},
-	Message, PublicKey, Secp256k1,
-};
+use secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
+use secp256k1::{Message, PublicKey, Secp256k1};
 use serde_derive::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
+
+use crate::{error::AttTrError, term::Term};
 
 pub mod security;
 pub mod status;

--- a/attestation-transformer/src/schemas/security.rs
+++ b/attestation-transformer/src/schemas/security.rs
@@ -1,11 +1,10 @@
-use super::{Domain, IntoTerm, Proof, Validation};
-use crate::{
-	did::{Did, Schema},
-	error::AttTrError,
-	term::Term,
-	utils::address_from_ecdsa_key,
-};
 use serde_derive::{Deserialize, Serialize};
+
+use crate::did::{Did, Schema};
+use crate::error::AttTrError;
+use crate::schemas::{Domain, IntoTerm, Proof, Validation};
+use crate::term::Term;
+use crate::utils::address_from_ecdsa_key;
 
 #[derive(Deserialize, Serialize, Clone)]
 pub enum SecurityStatus {
@@ -139,17 +138,14 @@ impl IntoTerm for SecurityReportSchema {
 
 #[cfg(test)]
 mod test {
-	use crate::{
-		did::Did,
-		schemas::{
-			security::{CredentialSubject, SecurityFinding, SecurityReportSchema, SecurityStatus},
-			Proof, Validation,
-		},
-		utils::address_from_ecdsa_key,
-	};
-
 	use secp256k1::{generate_keypair, rand::thread_rng, Message, Secp256k1};
 	use sha3::{Digest, Keccak256};
+
+	use crate::did::Did;
+	use crate::schemas::{Proof, Validation};
+	use crate::utils::address_from_ecdsa_key;
+
+	use super::*;
 
 	#[test]
 	fn should_validate_audit_report_schema() {

--- a/attestation-transformer/src/schemas/status.rs
+++ b/attestation-transformer/src/schemas/status.rs
@@ -1,8 +1,10 @@
-use crate::did::Schema;
-use crate::{did::Did, error::AttTrError, term::Term, utils::address_from_ecdsa_key};
 use serde_derive::{Deserialize, Serialize};
 
-use super::{Domain, IntoTerm, Proof, Validation};
+use crate::did::{Did, Schema};
+use crate::error::AttTrError;
+use crate::schemas::{Domain, IntoTerm, Proof, Validation};
+use crate::term::Term;
+use crate::utils::address_from_ecdsa_key;
 
 #[derive(Deserialize, Serialize, Clone)]
 pub enum CurrentStatus {
@@ -101,12 +103,15 @@ impl IntoTerm for StatusSchema {
 
 #[cfg(test)]
 mod test {
-	use crate::schemas::status::{CredentialSubject, StatusSchema};
+	use secp256k1::rand::thread_rng;
+	use secp256k1::{generate_keypair, Message, Secp256k1};
+	use sha3::{Digest, Keccak256};
+
+	use crate::did::Did;
 	use crate::schemas::{Proof, Validation};
 	use crate::utils::address_from_ecdsa_key;
-	use crate::{did::Did, schemas::status::CurrentStatus};
-	use secp256k1::{generate_keypair, rand::thread_rng, Message, Secp256k1};
-	use sha3::{Digest, Keccak256};
+
+	use super::*;
 
 	#[test]
 	fn should_validate_endorse_credential() {

--- a/attestation-transformer/src/schemas/trust.rs
+++ b/attestation-transformer/src/schemas/trust.rs
@@ -1,11 +1,10 @@
-use super::{Domain, IntoTerm, Proof, Validation};
-use crate::{
-	did::{Did, Schema},
-	error::AttTrError,
-	term::Term,
-	utils::address_from_ecdsa_key,
-};
 use serde_derive::{Deserialize, Serialize};
+
+use crate::did::{Did, Schema};
+use crate::error::AttTrError;
+use crate::schemas::{Domain, IntoTerm, Proof, Validation};
+use crate::term::Term;
+use crate::utils::address_from_ecdsa_key;
 
 #[derive(Deserialize, Serialize, Clone)]
 pub struct DomainTrust {
@@ -134,18 +133,15 @@ impl IntoTerm for TrustSchema {
 
 #[cfg(test)]
 mod test {
-	use crate::{
-		did::Did,
-		schemas::{
-			trust::{CredentialSubject, DomainTrust},
-			Domain, Proof, Validation,
-		},
-		utils::address_from_ecdsa_key,
-	};
-
-	use super::TrustSchema;
-	use secp256k1::{generate_keypair, rand::thread_rng, Message, Secp256k1};
+	use secp256k1::rand::thread_rng;
+	use secp256k1::{generate_keypair, Message, Secp256k1};
 	use sha3::{Digest, Keccak256};
+
+	use crate::did::Did;
+	use crate::schemas::{Domain, Proof, Validation};
+	use crate::utils::address_from_ecdsa_key;
+
+	use super::*;
 
 	#[test]
 	fn should_validate_trust_schema() {

--- a/attestation-transformer/src/term.rs
+++ b/attestation-transformer/src/term.rs
@@ -1,5 +1,6 @@
-use crate::error::AttTrError;
 use proto_buf::transformer::{Form, TermObject};
+
+use crate::error::AttTrError;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum TermForm {
@@ -178,7 +179,7 @@ impl From<Term> for TermObject {
 
 #[cfg(test)]
 mod test {
-	use super::{Term, TermForm};
+	use super::*;
 
 	#[test]
 	fn should_convert_term_to_bytes_and_back() {

--- a/attestation-transformer/src/utils.rs
+++ b/attestation-transformer/src/utils.rs
@@ -11,9 +11,11 @@ pub fn address_from_ecdsa_key(pub_key: &PublicKey) -> Vec<u8> {
 
 #[cfg(test)]
 mod test {
-	use super::address_from_ecdsa_key;
-	use secp256k1::PublicKey;
 	use std::str::FromStr;
+
+	use secp256k1::PublicKey;
+
+	use super::*;
 
 	#[test]
 	fn should_recreate_address_and_did_from_pk() {

--- a/indexer/src/clients/clique/client.rs
+++ b/indexer/src/clients/clique/client.rs
@@ -1,25 +1,16 @@
-use ethers::{
-	abi::RawLog,
-	contract::decode_logs,
-	core::types::{Address, Filter},
-	prelude::abigen,
-	providers::{
-		Http,
-		Middleware,
-		Provider,
-		// Ws
-	},
-};
-
-use tracing::debug;
-
-use eyre::Result;
 use std::cmp;
 use std::error::Error;
 use std::sync::Arc;
 
-use super::types::EVMIndexerConfig;
-pub use crate::clients::types::EVMLogsClient;
+use ethers::abi::RawLog;
+use ethers::contract::decode_logs;
+use ethers::core::types::{Address, Filter};
+use ethers::prelude::abigen;
+use ethers::providers::{Http, Middleware, Provider};
+use eyre::Result;
+use tracing::debug;
+
+use crate::clients::clique::types::EVMIndexerConfig;
 
 pub struct CliqueClient {
 	config: EVMIndexerConfig,

--- a/indexer/src/clients/csv/client.rs
+++ b/indexer/src/clients/csv/client.rs
@@ -1,11 +1,11 @@
-use csv::{ReaderBuilder, StringRecord};
-use eyre::Result;
 use std::error::Error;
 use std::fs::File;
+
+use csv::{ReaderBuilder, StringRecord};
+use eyre::Result;
 use tracing::debug;
 
-use super::types::CSVClientConfig;
-pub use crate::clients::types::EVMLogsClient;
+use crate::clients::csv::types::CSVClientConfig;
 
 pub struct CSVClient {
 	config: CSVClientConfig,

--- a/indexer/src/config/dotenv.rs
+++ b/indexer/src/config/dotenv.rs
@@ -1,9 +1,11 @@
+use std::env;
+
+use dotenv::dotenv;
+use tracing::Level;
+
 use crate::clients::clique::types::EVMIndexerConfig;
 use crate::frontends::api::grpc_server::types::GRPCServerConfig;
 use crate::storage::lm_db::types::LMDBClientConfig;
-use dotenv::dotenv;
-use std::env;
-use tracing::Level;
 
 // types to components
 #[derive(Clone, Debug)]

--- a/indexer/src/frontends/api/grpc_server/mod.rs
+++ b/indexer/src/frontends/api/grpc_server/mod.rs
@@ -1,15 +1,19 @@
-use crate::frontends::api::grpc_server::types::GRPCServerConfig;
-use crate::tasks::service::{TaskResponse, TaskService};
-use proto_buf::indexer::indexer_server::{Indexer, IndexerServer};
-use proto_buf::indexer::{IndexerEvent, Query};
 use std::cmp;
 use std::error::Error;
 use std::time::SystemTime;
+
 use tokio::sync::mpsc::channel;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
 use tracing::info;
+
+use proto_buf::indexer::indexer_server::{Indexer, IndexerServer};
+use proto_buf::indexer::{IndexerEvent, Query};
+
+use crate::frontends::api::grpc_server::types::GRPCServerConfig;
+use crate::tasks::service::TaskService;
+use crate::tasks::types::TaskResponse;
 
 pub mod types;
 

--- a/indexer/src/logger/global.rs
+++ b/indexer/src/logger/global.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
-use tracing_subscriber::FmtSubscriber;
 
 use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::FmtSubscriber;
 
 // move logger config here
 use crate::config::dotenv::LoggerConfig;

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -1,3 +1,14 @@
+use clap::Parser;
+use tracing::info;
+
+use crate::clients::csv::{client::CSVClient, types::CSVClientConfig};
+use crate::config::dotenv::Config;
+use crate::frontends::api::grpc_server::GRPCServer;
+use crate::logger::global::AppLogger;
+use crate::storage::lm_db::LMDBClient;
+use crate::tasks::csv_poc::task::CSVPOCTask;
+use crate::tasks::service::TaskService;
+
 pub mod cli;
 pub mod clients;
 pub mod config;
@@ -5,20 +16,6 @@ pub mod frontends;
 pub mod logger;
 pub mod storage;
 pub mod tasks;
-
-use clap::Parser;
-use tracing::info;
-
-use crate::logger::global::AppLogger;
-use crate::tasks::service::TaskService;
-use frontends::api::grpc_server::GRPCServer;
-use storage::lm_db::LMDBClient;
-
-use crate::clients::csv::{client::CSVClient, types::CSVClientConfig};
-
-use crate::tasks::csv_poc::task::CSVPOCTask;
-
-use crate::config::dotenv::Config;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/indexer/src/storage/lm_db/mod.rs
+++ b/indexer/src/storage/lm_db/mod.rs
@@ -1,8 +1,10 @@
-use crate::storage::lm_db::types::LMDBClientConfig;
-use crate::storage::types::BaseKVStorage;
+use std::fs;
+
 use heed::types::Str;
 use heed::{Database, EnvOpenOptions};
-use std::fs;
+
+use crate::storage::lm_db::types::LMDBClientConfig;
+use crate::storage::types::BaseKVStorage;
 
 pub mod types;
 

--- a/indexer/src/tasks/clique/task.rs
+++ b/indexer/src/tasks/clique/task.rs
@@ -1,5 +1,3 @@
-use tracing::{debug, info};
-
 use std::time::Duration;
 
 use digest::Digest;
@@ -7,13 +5,12 @@ use hex;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use sha3::Sha3_256;
+use tracing::{debug, info};
 
-pub use crate::clients::types::EVMLogsClient;
 // todo change to EVMLogsClient, make threadsafe
-pub use crate::clients::clique::client::CliqueClient;
-pub use crate::clients::clique::types::EVMIndexerConfig;
-
-pub use crate::tasks::types::{BaseTask, BaseTaskState, TaskResponse};
+use crate::clients::clique::client::CliqueClient;
+use crate::clients::clique::types::EVMIndexerConfig;
+use crate::tasks::types::{BaseTask, BaseTaskState, TaskResponse};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CliqueTaskState {

--- a/indexer/src/tasks/csv_poc/task.rs
+++ b/indexer/src/tasks/csv_poc/task.rs
@@ -1,13 +1,14 @@
+use std::time::Duration;
+
 use digest::Digest;
 use hex;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use sha3::Sha3_256;
-use std::time::Duration;
 use tracing::{debug, info};
 
-pub use crate::clients::csv::client::CSVClient;
-pub use crate::tasks::types::{BaseTask, BaseTaskState, TaskResponse};
+use crate::clients::csv::client::CSVClient;
+use crate::tasks::types::{BaseTask, BaseTaskState, TaskResponse};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CSVPOCTaskState {

--- a/indexer/src/tasks/service.rs
+++ b/indexer/src/tasks/service.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use tracing::info;
 
 use crate::storage::types::BaseKVStorage;
-pub use crate::tasks::types::{BaseTask, TaskResponse};
+use crate::tasks::types::{BaseTask, TaskResponse};
 
 pub struct TaskService {
 	task: Box<dyn BaseTask>,

--- a/indexer/src/tasks/types.rs
+++ b/indexer/src/tasks/types.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
 
 // todo better layer separation
 #[tonic::async_trait]

--- a/job-manager/src/main.rs
+++ b/job-manager/src/main.rs
@@ -1,14 +1,16 @@
-use proto_buf::combiner::linear_combiner_client::LinearCombinerClient;
-use proto_buf::combiner::{LtBatch, LtHistoryBatch};
-use proto_buf::transformer::transformer_client::TransformerClient;
-use proto_buf::transformer::{EventBatch, TermBatch};
 use std::error::Error;
 use std::time::Duration;
+
 use tokio::time::interval;
 use tokio_stream::wrappers::IntervalStream;
 use tokio_stream::StreamExt;
 use tonic::transport::Channel;
 use tonic::Request;
+
+use proto_buf::combiner::linear_combiner_client::LinearCombinerClient;
+use proto_buf::combiner::{LtBatch, LtHistoryBatch};
+use proto_buf::transformer::transformer_client::TransformerClient;
+use proto_buf::transformer::{EventBatch, TermBatch};
 
 const BATCH_SIZE: u32 = 1000;
 const INTERVAL_SECS: u64 = 5;

--- a/linear-combiner/src/main.rs
+++ b/linear-combiner/src/main.rs
@@ -1,21 +1,21 @@
-use error::LcError;
-use managers::{
-	checkpoint::CheckpointManager, index::IndexManager, item::ItemManager, mapping::MappingManager,
-	update::UpdateManager,
-};
-use proto_buf::{
-	combiner::{
-		linear_combiner_server::{LinearCombiner, LinearCombinerServer},
-		LtBatch, LtHistoryBatch, LtObject, Mapping, MappingQuery,
-	},
-	common::Void,
-	transformer::TermObject,
-};
-use rocksdb::{Options, DB};
 use std::error::Error;
+
+use rocksdb::{Options, DB};
 use tokio::sync::mpsc::channel;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{transport::Server, Request, Response, Status, Streaming};
+
+use proto_buf::combiner::linear_combiner_server::{LinearCombiner, LinearCombinerServer};
+use proto_buf::combiner::{LtBatch, LtHistoryBatch, LtObject, Mapping, MappingQuery};
+use proto_buf::common::Void;
+use proto_buf::transformer::TermObject;
+
+use crate::error::LcError;
+use crate::managers::checkpoint::CheckpointManager;
+use crate::managers::index::IndexManager;
+use crate::managers::item::ItemManager;
+use crate::managers::mapping::MappingManager;
+use crate::managers::update::UpdateManager;
 
 pub mod error;
 pub mod item;

--- a/linear-combiner/src/managers/checkpoint.rs
+++ b/linear-combiner/src/managers/checkpoint.rs
@@ -38,8 +38,9 @@ impl CheckpointManager {
 
 #[cfg(test)]
 mod test {
-	use crate::managers::checkpoint::CheckpointManager;
 	use rocksdb::{Options, DB};
+
+	use super::*;
 
 	#[test]
 	fn should_write_read_checkpoint() {

--- a/linear-combiner/src/managers/index.rs
+++ b/linear-combiner/src/managers/index.rs
@@ -1,5 +1,6 @@
-use crate::error::LcError;
 use rocksdb::DB;
+
+use crate::error::LcError;
 
 #[derive(Debug)]
 pub struct IndexManager;
@@ -26,8 +27,9 @@ impl IndexManager {
 
 #[cfg(test)]
 mod test {
-	use crate::managers::index::IndexManager;
 	use rocksdb::{Options, DB};
+
+	use super::*;
 
 	#[test]
 	fn should_update_and_get_index() {

--- a/linear-combiner/src/managers/item.rs
+++ b/linear-combiner/src/managers/item.rs
@@ -1,6 +1,7 @@
 use rocksdb::DB;
 
-use crate::{error::LcError, item::LtItem};
+use crate::error::LcError;
+use crate::item::LtItem;
 
 #[derive(Debug)]
 pub struct ItemManager;
@@ -56,8 +57,11 @@ impl ItemManager {
 
 #[cfg(test)]
 mod test {
-	use crate::{item::LtItem, managers::item::ItemManager};
 	use rocksdb::{Options, DB};
+
+	use crate::item::LtItem;
+
+	use super::*;
 
 	#[test]
 	fn should_update_item() {

--- a/linear-combiner/src/managers/mapping.rs
+++ b/linear-combiner/src/managers/mapping.rs
@@ -1,5 +1,7 @@
-use crate::{error::LcError, item::MappingItem};
 use rocksdb::{Direction, IteratorMode, DB};
+
+use crate::error::LcError;
+use crate::item::MappingItem;
 
 #[derive(Debug)]
 pub struct MappingManager;

--- a/linear-combiner/src/managers/update.rs
+++ b/linear-combiner/src/managers/update.rs
@@ -1,6 +1,7 @@
 use rocksdb::{IteratorMode, WriteBatch, DB};
 
-use crate::{error::LcError, item::LtItem};
+use crate::error::LcError;
+use crate::item::LtItem;
 
 #[derive(Debug)]
 pub struct UpdateManager;
@@ -48,8 +49,11 @@ impl UpdateManager {
 
 #[cfg(test)]
 mod test {
-	use crate::{item::LtItem, managers::update::UpdateManager};
 	use rocksdb::{Options, DB};
+
+	use crate::item::LtItem;
+
+	use super::*;
 
 	#[test]
 	fn should_read_delete_batch() {


### PR DESCRIPTION
Order imports into groups (IntelliJ and RustRover use this convention):

  - `std::`
  - external
  - workspace
  - `crate::`
  - relative (`super::`/`self::`)

Do not curly-brace group imports from separate modules.

Prefer crate imports to relative imports, per the Rust Book. The only exception is `use super::*` from test modules.

Remove unused imports.

Avoid re-exports (`pub use`).